### PR TITLE
Fix video explanations on the same line as text

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,17 +4,21 @@
 ---
 ## Save Editor
 [Video Explanation](https://www.youtube.com/watch?v=YyinHRy9Qtw)
+
 The Save Editor is a piece of software that is designed for preparing a campaign, wether that be in the making a concept, storing story line and plot hooks
 
 ## Client
 [Video Explanation](https://www.youtube.com/watch?v=YyinHRy9Qtw)
+
 The Client is where the players join the campaign and actualy interface with the session. They can view pokedex entrys, see entities and much more.
 
 ## Server
 #### Integrated Server
 [Video Explanation](https://www.youtube.com/watch?v=YyinHRy9Qtw)
+
 The Intergrated Server 
 
 #### Dedicated Server
 [Video Explanation](https://www.youtube.com/watch?v=YyinHRy9Qtw)
+
 The Dedicated Server is similar to how the client can host servers with the main difference being that the GM does not need to be online with a client running for players to connect... It is a persistant server that is always running unless it is commanded to stop.


### PR DESCRIPTION
The video explanations were on the same line as the text, which looks strange.